### PR TITLE
Only report lower-case extensions

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -200,7 +200,7 @@ void retro_get_system_info(struct retro_system_info *info)
 {
    info->library_name = "dosbox";
    info->library_version = "svn";
-   info->valid_extensions = "exe|com|bat|conf|EXE|COM|BAT|CONF";
+   info->valid_extensions = "exe|com|bat|conf";
    info->need_fullpath = true;
    info->block_extract = false;
 }


### PR DESCRIPTION
According to a little script I wrote, DOSBox is the last libretro core to still report lower and upper case supported extensions
