### PR TITLE
Fix android ndk removing ftime

### DIFF
--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -503,7 +503,7 @@ void FAKEftime(struct FAKEtimeb* tb)
 {
    time(&tb->time);
    
-#ifndef __WIN32__
+#if defined(__linux__) || defined(__unix__)
    struct timeval tv;
    gettimeofday(&tv, NULL);
    tb->millitm = tv.tv_usec/1000;


### PR DESCRIPTION
Also now retrieves valid milliseconds without ftime.