### PR TITLE
Fix infinite loop on exit

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -593,10 +593,10 @@ static void retro_wrap_emulator(void)
    retro_start_emulator();
 
    // Exit comes from DOSBox, tell the frontend
-   /*if(DOSBOXwantsExit)
+   if(DOSBOXwantsExit)
    {
       environ_cb(RETRO_ENVIRONMENT_SHUTDOWN, 0);
-   }*/
+   }
 
    // Were done here
    co_switch(mainThread);


### PR DESCRIPTION
When I typed "exit", dosbox went into an infinite loop instead of exiting to Kodi