### PR TITLE
Add Libretro MIDI output support

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -57,6 +57,7 @@ extern Bit32s CPU_CycleMax;
 extern Bit32s CPU_CycleLimit;
 extern bool CPU_CycleAutoAdjust;
 extern bool CPU_SkipCycleAutoAdjust;
+extern struct retro_midi_interface *Midi_retro_interface;
 
 MachineType machine = MCH_VGA;
 SVGACards svgaCard = SVGA_None;
@@ -464,6 +465,16 @@ void retro_init (void)
    if (log_cb)
       log_cb(RETRO_LOG_INFO, "Logger interface initialized... \n");
 
+   static struct retro_midi_interface midi_interface;
+   if(environ_cb(RETRO_ENVIRONMENT_GET_MIDI_INTERFACE, &midi_interface))
+     Midi_retro_interface = &midi_interface;
+   else
+     Midi_retro_interface = NULL;
+
+   if (log_cb)
+     log_cb(RETRO_LOG_INFO, "MIDI interface %s.\n",
+         Midi_retro_interface ? "initialized" : "unavailable");
+
    RDOSGFXcolorMode = RETRO_PIXEL_FORMAT_XRGB8888;
    environ_cb(RETRO_ENVIRONMENT_SET_PIXEL_FORMAT, &RDOSGFXcolorMode);
    if(!emuThread && !mainThread)
@@ -606,6 +617,8 @@ void retro_run (void)
       RETROLOG("retro_run called when there is no emulator thread.");
    }
 
+   if (Midi_retro_interface && Midi_retro_interface->output_enabled())
+     Midi_retro_interface->flush();
 }
 
 // Stubs

--- a/libretro/libretro.h
+++ b/libretro/libretro.h
@@ -1156,6 +1156,23 @@ struct retro_hw_render_context_negotiation_interface
                                             * so it will be used after SET_HW_RENDER, but before the context_reset callback.
                                             */
 
+#define RETRO_ENVIRONMENT_GET_MIDI_INTERFACE (48 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+
+typedef bool (RETRO_CALLCONV *retro_midi_input_enabled_t)(void);
+typedef bool (RETRO_CALLCONV *retro_midi_output_enabled_t)(void);
+typedef bool (RETRO_CALLCONV *retro_midi_read_t)(uint8_t *byte);
+typedef bool (RETRO_CALLCONV *retro_midi_write_t)(uint8_t byte, uint32_t delta_time);
+typedef bool (RETRO_CALLCONV *retro_midi_flush_t)(void);
+
+struct retro_midi_interface
+{
+   retro_midi_input_enabled_t input_enabled;
+   retro_midi_output_enabled_t output_enabled;
+   retro_midi_read_t read;
+   retro_midi_write_t write;
+   retro_midi_flush_t flush;
+};
+
 /* Serialized state is incomplete in some way. Set if serialization is
  * usable in typical end-user cases but should not be relied upon to
  * implement frame-sensitive frontend features such as netplay or


### PR DESCRIPTION
Old code in 'MIDI_RawOutByte' function in 'midi.cpp' probably may be conditionally compiled-out after this changes.