### PR TITLE
Fix struct "retro_midi_interface" being defined twice

### DIFF
--- a/libretro/libretro.h
+++ b/libretro/libretro.h
@@ -1210,15 +1210,6 @@ typedef bool (RETRO_CALLCONV *retro_midi_write_t)(uint8_t byte, uint32_t delta_t
  * Returns true if successful, false otherwise. */
 typedef bool (RETRO_CALLCONV *retro_midi_flush_t)(void);
 
-struct retro_midi_interface
-{
-   retro_midi_input_enabled_t input_enabled;
-   retro_midi_output_enabled_t output_enabled;
-   retro_midi_read_t read;
-   retro_midi_write_t write;
-   retro_midi_flush_t flush;
-};
-
 #define RETRO_ENVIRONMENT_GET_HW_RENDER_INTERFACE (41 | RETRO_ENVIRONMENT_EXPERIMENTAL)
                                            /* const struct retro_hw_render_interface ** --
                                             * Returns an API specific rendering interface for accessing API specific data.


### PR DESCRIPTION
The core fails to compile due to the struct `retro_midi_interface` being defined twice in libretro.h.  Removing one of the struct definitions allows the core to compile correctly.