### PR TITLE
reduce deadzone for gamepad mouse to increase precision

### DIFF
--- a/libretro/mapper.cpp
+++ b/libretro/mapper.cpp
@@ -544,7 +544,7 @@ void MAPPER_Run(bool pressed)
     int16_t mouseX = input_cb(0, RDEV(MOUSE), 0, RDID(MOUSE_X));
     int16_t mouseY = input_cb(0, RDEV(MOUSE), 0, RDID(MOUSE_Y));
 
-    const int deadzone = 30;
+    const int deadzone = 5;
     const int speed = 8;
 
     if (emulated_mouse)


### PR DESCRIPTION
This increases the dynamic range of pointer speeds accessible by the right analog stick joystick mouse. See also https://github.com/libretro/RetroArch/issues/8502 . Although this doesn't fix that issue, at least it makes the joystick mouse in dosbox more finely controllable.

After discussion with radius on GitHub, the original large deadzone value of 30% was most probably a leftover value from testing/debugging the core.
