### PR TITLE
Change working directory when loading conf file

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -460,6 +460,10 @@ static void start_dosbox(void)
     control = &myconf;
     check_variables();
 
+    /* Change current directory to config directory */
+    if(!configPath.empty())
+        chdir(configPath.substr(0, configPath.find_last_of(PATH_SEPARATOR)).c_str());
+
     /* Init the configuration system and add default values */
     DOSBOX_Init();
 


### PR DESCRIPTION
This is my quick "fix" for #92. I don't know if `chdir` is the best solution at this point. I would prefer a config option instead of changing the current working directory for the whole process.

This is needed if one is loading a `dosbox.conf` configuration file directly. Without this patch the following would not be possible:

```bat
[autoexec]
mount D .
D:
FOOBAR.EXE
```

My concrete use case is mounting the current directory as a cdrom image (which is not directly possible when calling the `EXE`):

```bat
[autoexec]
mount D . -t cdrom
D:
RAYMAN
EXIT
```

It is even possible to start Win 3.11 games using this technique. Just place a shared installed Win 3.11 directory in the parent path. Then:

```bat
[autoexec]
MOUNT C ../WIN311/drive_c
MOUNT D .
C:
cd WINDOWS
WIN D:\DRBRAIN3.EXE
EXIT
```