### PR TITLE
Makefile fix to enable build for "unix-armv7-hardfloat-neon"

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -57,11 +57,14 @@ else ifeq ($(target), nintendoc)
 endif
 
 # flags
-ifeq ($(platform), unix)
+ifneq ($(findstring unix,$(platform)),)
 	COMMONFLAGS += -DC_HAVE_MPROTECT="1"
 	TARGET := $(TARGET_NAME)_libretro.so
 	LDFLAGS += -shared -Wl,--version-script=libretro/link.T
 	fpic = -fPIC
+	ifneq ($(findstring armv,$(platform)),)
+		WITH_DYNAREC = arm
+	endif
 else ifeq ($(platform), osx)
 	COMMONFLAGS += -DC_HAVE_MPROTECT="1"
 	ifneq ($(findstring arm64,$(UNAMEM)),)


### PR DESCRIPTION
Compilation was not successful for "unix-armv7-hardfloat-neon" (one of the options in libretro-super build scripts). Added minimal support.