### PR TITLE
Add GitLab CI (Linux, Windows, macOS, Android)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,117 @@
+# DESCRIPTION: GitLab CI/CD for libRetro (NOT FOR GitLab-proper)
+
+##############################################################################
+################################# BOILERPLATE ################################
+##############################################################################
+
+# Core definitions
+.core-defs:
+  variables:
+    JNI_PATH: jni
+    MAKEFILE: Makefile.libretro
+    CORENAME: dosbox
+
+# Inclusion templates, required for the build to work
+include:
+  ################################## DESKTOPS ################################
+  # Linux 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-x64.yml'
+
+  # Linux 32-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-i686.yml'
+
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+
+  # Windows 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/windows-x64-mingw.yml'
+
+  # MacOS ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/osx-arm64.yml'
+
+  ################################## CELLULAR ################################
+  # Android
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/android-jni.yml'
+
+# Stages for building
+stages:
+  - build-prepare
+  - build-shared
+  - build-static
+
+##############################################################################
+#################################### STAGES ##################################
+##############################################################################
+#
+################################### DESKTOPS #################################
+# Linux 64-bit
+libretro-build-linux-x64:
+  extends:
+    - .libretro-linux-x64-make-default
+    - .core-defs
+
+# Linux 32-bit
+libretro-build-linux-i686:
+  extends:
+    - .libretro-linux-i686-make-default
+    - .core-defs
+
+# Linux ARM 64-bit
+# No dynarec: this fork only carries the armv4le, x86, x86_64 and mipsel
+# backends, so aarch64 runs the interpreter.
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
+    - .core-defs
+
+# Windows 64-bit
+# The makefile knows platform=win, not win64, and cannot guess the dynarec
+# when it is cross compiled from Linux.
+libretro-build-windows-x64:
+  extends:
+    - .libretro-windows-x64-mingw-make-default
+    - .core-defs
+  variables:
+    platform: win
+    WITH_DYNAREC: x86_64
+
+# MacOS ARM 64-bit
+libretro-build-osx-arm64:
+  extends:
+    - .libretro-osx-arm64-make-default
+    - .core-defs
+
+################################### CELLULAR #################################
+# Only the 64-bit ABIs: the NDK's clang rejects both 32-bit dynarecs -- the
+# ARM one writes to r7 (its frame pointer) from inline asm, and the x86 one
+# is not position independent.
+#
+# Android ARMv7a
+#android-armeabi-v7a:
+#  extends:
+#    - .libretro-android-jni-armeabi-v7a
+#    - .core-defs
+
+# Android ARMv8a
+android-arm64-v8a:
+  extends:
+    - .libretro-android-jni-arm64-v8a
+    - .core-defs
+
+# Android 32-bit x86
+#android-x86:
+#  extends:
+#    - .libretro-android-jni-x86
+#    - .core-defs
+
+# Android 64-bit x86
+android-x86_64:
+  extends:
+    - .libretro-android-jni-x86_64
+    - .core-defs

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,2 +1,4 @@
 APP_STL := c++_static
 APP_ABI := all
+# dosbox still uses `register`, which is an error under the NDK's default C++17
+APP_CPPFLAGS := -std=gnu++14


### PR DESCRIPTION
The repo has never had a `.gitlab-ci.yml`, so no pipeline has ever run and there is no build of this core on the buildbot.

Jobs: `linux-x64`, `linux-i686`, `linux-aarch64`, `windows-x64`, `osx-arm64` and the two 64-bit Android ABIs. Three things the file has to say out loud:

- the makefile knows `platform=win`, not the template's `win64`, and cannot guess a dynarec when it is cross compiled from Linux, so the Windows job passes both;
- aarch64 gets no dynarec — this fork only carries the armv4le, x86, x86_64 and mipsel backends;
- `Application.mk` pins `gnu++14`: the sources still use `register`, which the NDK's default C++17 rejects outright.

armeabi-v7a and android-x86 are left commented out with the reason: the NDK's clang refuses the 32-bit dynarecs (the ARM one writes to r7, its frame pointer, from inline asm; the x86 one is not position independent).

Everything enabled here was validated by replaying the jobs — `ubuntu:xenial` amd64/i386 with gcc-9 and `ubuntu:focal` arm64 containers, mingw-w64, an Apple Silicon runner, and `ndk-build` per ABI.