### PR TITLE
Fix the buildbot Android and macOS jobs, and add the 32-bit Android ABIs and webOS

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,9 @@
 # Core definitions
 .core-defs:
   variables:
-    JNI_PATH: jni
+    # Not JNI_PATH: the android-jni template appends /jni to it itself, so
+    # naming the directory here made it look for jni/jni and stop before it
+    # compiled anything. The default, ".", is what this repository wants.
     MAKEFILE: Makefile.libretro
     CORENAME: dosbox
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,6 +36,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/osx-arm64.yml'
 
+  # webOS
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/webos-make.yml'
+
   ################################## CELLULAR ################################
   # Android
   - project: 'libretro-infrastructure/ci-templates'
@@ -89,16 +93,25 @@ libretro-build-osx-arm64:
     - .libretro-osx-arm64-make-default
     - .core-defs
 
+# webOS ARMv7a
+# The makefile guesses the dynarec from `uname -m` on platform=unix, which is
+# the build host here, so the target's own has to be named.
+libretro-build-webos-armv7a:
+  extends:
+    - .libretro-webos-armv7a-make-default
+    - .core-defs
+  variables:
+    WITH_DYNAREC: arm
+
 ################################### CELLULAR #################################
-# Only the 64-bit ABIs: the NDK's clang rejects both 32-bit dynarecs -- the
-# ARM one writes to r7 (its frame pointer) from inline asm, and the x86 one
-# is not position independent.
+# All four ABIs. The 32-bit two run the interpreter rather than a dynarec --
+# jni/Android.mk says why -- which is still a core where there was none.
 #
 # Android ARMv7a
-#android-armeabi-v7a:
-#  extends:
-#    - .libretro-android-jni-armeabi-v7a
-#    - .core-defs
+android-armeabi-v7a:
+  extends:
+    - .libretro-android-jni-armeabi-v7a
+    - .core-defs
 
 # Android ARMv8a
 android-arm64-v8a:
@@ -107,10 +120,10 @@ android-arm64-v8a:
     - .core-defs
 
 # Android 32-bit x86
-#android-x86:
-#  extends:
-#    - .libretro-android-jni-x86
-#    - .core-defs
+android-x86:
+  extends:
+    - .libretro-android-jni-x86
+    - .core-defs
 
 # Android 64-bit x86
 android-x86_64:

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -226,6 +226,15 @@ else
 endif
 
 OBJECTS  = $(sort $(SOURCES_CXX:.cpp=.o) $(SOURCES_C:.c=.o))
+# The C++ here is C++11 at least - setup.h uses noexcept - and C++14 at most,
+# since the dynarec headers still say `register`, which C++17 removed. Nothing
+# says which standard a compiler will pick by default: clang on macOS picks
+# gnu++98 and stops on the first noexcept, while the NDK picks C++17 and stops
+# on the first register. So say it, unless the platform above already has.
+ifeq ($(findstring -std=,$(CXXFLAGS)),)
+CXXFLAGS += -std=gnu++14
+endif
+
 CXXFLAGS += -D__LIBRETRO__ $(fpic) $(INCFLAGS) $(COMMONFLAGS)
 CFLAGS   += -D__LIBRETRO__ $(fpic) $(INCFLAGS) $(COMMONFLAGS)
 LIBM     ?= -lm

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -4,14 +4,13 @@ CORE_DIR := $(LOCAL_PATH)/..
 INCFLAGS    :=
 COMMONFLAGS :=
 
+# No dynarec on the 32-bit ABIs: the NDK's clang rejects both of them. The ARM
+# one writes to r7 from inline asm, which is the frame pointer and reserved,
+# and the x86 one is not position independent, which the NDK requires. Both
+# ABIs build and run on the interpreter, which is what they get - the
+# alternative is not building for them at all.
 WITH_DYNAREC :=
-ifeq ($(TARGET_ARCH_ABI), armeabi)
-    WITH_DYNAREC := oldarm
-else ifeq ($(TARGET_ARCH_ABI), armeabi-v7a)
-    WITH_DYNAREC := arm
-else ifeq ($(TARGET_ARCH_ABI), x86)
-    WITH_DYNAREC := x86
-else ifeq ($(TARGET_ARCH_ABI), x86_64)
+ifeq ($(TARGET_ARCH_ABI), x86_64)
     WITH_DYNAREC := x86_64
 endif
 


### PR DESCRIPTION
Android and macOS have failed on every pipeline since the CI landed.

**Android** never reached the compiler: `.core-defs` sets `JNI_PATH: jni`, but the template appends `/jni` to it itself (`ndk-build -C $JNI_PATH/jni`), so it looked for `jni/jni`. The default, `.`, is what this repository wants.

**macOS** stopped on the first `noexcept` in `include/setup.h` — nothing names a C++ standard and clang on macOS answers `gnu++98`. The makefile now says `gnu++14`: at least C++11 for that `noexcept` (#148), at most C++14 because the dynarec headers still say `register`, which is why `jni/Application.mk` already pins it.

The second commit adds what was missing rather than broken:

- **the 32-bit Android ABIs.** They were commented out because clang rejects their dynarecs (the ARM one writes to `r7`, the x86 one is not position independent) — a reason to drop those two dynarecs, not the core. `jni/Android.mk` leaves `WITH_DYNAREC` empty except for x86_64, and all four ABIs build on the interpreter.
- **webOS**, which is the Linux makefile with the SDK's toolchain. Its only quirk: on `platform=unix` the makefile guesses the dynarec from `uname -m`, i.e. the build host, so the job names the target's own.

Checked with the same commands the templates run — [before](https://github.com/WizzardSK/dosbox-libretro/actions/runs/33951926886), [after](https://github.com/WizzardSK/dosbox-libretro/actions/runs/33952228470), [the new targets](https://github.com/WizzardSK/dosbox-libretro/actions/runs/33952482480): osx-arm64 on an Apple Silicon runner, all four ABIs through `ndk-build`, and an `arm-linux-gnueabihf` cross build standing in for the webOS SDK. Happy to split the second commit off.
