### PR TITLE
ci: the platforms the makefile already supports

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,6 +73,27 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/vita-static.yml'
 
+  # Nintendo GameCube
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/ngc-static.yml'
+
+  # Nintendo Wii
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/wii-static.yml'
+
+  # PlayStation Portable
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/psp-static.yml'
+
+  # PlayStation 3
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/psl1ght-static.yml'
+
+  #################################### MISC ##################################
+  # Emscripten
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/emscripten-static.yml'
+
   # webOS
   - project: 'libretro-infrastructure/ci-templates'
     file: '/webos-make.yml'
@@ -189,6 +210,36 @@ libretro-build-libnx-aarch64:
 libretro-build-vita:
   extends:
     - .libretro-vita-static-retroarch-master
+    - .core-defs
+
+# Nintendo GameCube
+libretro-build-ngc:
+  extends:
+    - .libretro-ngc-static-retroarch-master
+    - .core-defs
+
+# Nintendo Wii
+libretro-build-wii:
+  extends:
+    - .libretro-wii-static-retroarch-master
+    - .core-defs
+
+# PlayStation Portable
+libretro-build-psp:
+  extends:
+    - .libretro-psp-static-retroarch-master
+    - .core-defs
+
+# PlayStation 3
+libretro-build-psl1ght:
+  extends:
+    - .libretro-psl1ght-static-retroarch-master
+    - .core-defs
+
+# Emscripten
+libretro-build-emscripten:
+  extends:
+    - .libretro-emscripten-static-retroarch-master
     - .core-defs
 
 # webOS ARMv7a

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,9 +32,46 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/windows-x64-mingw.yml'
 
+  # Windows 32-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/windows-i686-mingw.yml'
+
+  # MacOS 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/osx-x64.yml'
+
   # MacOS ARM 64-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/osx-arm64.yml'
+
+  # iOS
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/ios-arm64.yml'
+
+  # iOS (armv7)
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/ios9.yml'
+
+  # tvOS
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/tvos-arm64.yml'
+
+  ################################## CONSOLES ################################
+  # Nintendo 3DS
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/ctr-static.yml'
+
+  # Nintendo WiiU
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/wiiu-static.yml'
+
+  # Nintendo Switch
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/libnx-static.yml'
+
+  # PlayStation Vita
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/vita-static.yml'
 
   # webOS
   - project: 'libretro-infrastructure/ci-templates'
@@ -87,10 +124,71 @@ libretro-build-windows-x64:
     platform: win
     WITH_DYNAREC: x86_64
 
+# Windows 32-bit
+libretro-build-windows-i686:
+  extends:
+    - .libretro-windows-i686-mingw-make-default
+    - .core-defs
+  variables:
+    platform: win
+    WITH_DYNAREC: x86
+
+# MacOS 64-bit
+libretro-build-osx-x64:
+  extends:
+    - .libretro-osx-x64-make-default
+    - .core-defs
+
 # MacOS ARM 64-bit
 libretro-build-osx-arm64:
   extends:
     - .libretro-osx-arm64-make-default
+    - .core-defs
+
+# iOS
+libretro-build-ios-arm64:
+  extends:
+    - .libretro-ios-arm64-make-default
+    - .core-defs
+
+# iOS (armv7) [iOS 9 and up]
+libretro-build-ios9:
+  extends:
+    - .libretro-ios9-make-default
+    - .core-defs
+
+# tvOS
+libretro-build-tvos-arm64:
+  extends:
+    - .libretro-tvos-arm64-make-default
+    - .core-defs
+
+################################### CONSOLES #################################
+# All four run the interpreter: this fork's dynarec backends are armv4le, x86,
+# x86_64 and mipsel, and none of these is one of those.
+#
+# Nintendo 3DS
+libretro-build-ctr:
+  extends:
+    - .libretro-ctr-static-retroarch-master
+    - .core-defs
+
+# Nintendo WiiU
+libretro-build-wiiu:
+  extends:
+    - .libretro-wiiu-static-retroarch-master
+    - .core-defs
+
+# Nintendo Switch
+libretro-build-libnx-aarch64:
+  extends:
+    - .libretro-libnx-static-retroarch-master
+    - .core-defs
+
+# PlayStation Vita
+libretro-build-vita:
+  extends:
+    - .libretro-vita-static-retroarch-master
     - .core-defs
 
 # webOS ARMv7a


### PR DESCRIPTION
Fourteen targets that `Makefile.libretro` has supported all along and the CI never built: **Windows 32-bit, MacOS x64, iOS arm64, iOS 9, tvOS, 3DS, WiiU, Switch, Vita, GameCube, Wii, PSP, PS3 and Emscripten**.

Nothing here teaches the core a new platform. Every one of these already has a branch in the makefile, and each resolves to the file name its template expects:

```
ios-arm64  -> dosbox_libretro_ios.dylib     ctr     -> dosbox_libretro_ctr.a
ios9       -> dosbox_libretro_ios.dylib     wiiu    -> dosbox_libretro_wiiu.a
tvos-arm64 -> dosbox_libretro_tvos.dylib    libnx   -> dosbox_libretro_libnx.a
osx        -> dosbox_libretro.dylib         vita    -> dosbox_libretro_vita.a
win        -> dosbox_libretro.dll           ngc     -> dosbox_libretro_ngc.a
                                            wii     -> dosbox_libretro_wii.a
                                            psp1    -> dosbox_libretro_psp1.a
                                            psl1ght -> dosbox_libretro_psl1ght.a
                                            emscripten -> dosbox_libretro_emscripten.bc
```

So the jobs are plain. Two carry a variable: Windows 32-bit needs `platform: win` and `WITH_DYNAREC: x86`, for the same reason the existing x64 job does — the makefile knows `win` rather than `win32` and cannot guess a dynarec when cross compiled from Linux.

Everything from 3DS down runs the interpreter. This fork's dynarec backends are armv4le, x86, x86_64 and mipsel, and none of those platforms is one of them — the same note the aarch64 job already carries. For a core this small that is not much of a loss, and an interpreter build is still a core where there was none.

**What is checked and what is not.** The makefile parses and resolves correctly for all fourteen, which is what can be established without the hardware. Whether each one links is for the buildbot to say. I would rather send them together and drop whichever fail than add them one a week: none is load-bearing for the platforms that build today, so a failure costs a line of YAML.

`genode`, `ps3` and `qnx` are left out — no template for the first and last, and `ps3` is `psl1ght` under another name.
